### PR TITLE
Add development setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ $ docker run -it trailofbits/tourniquet
 
 Enter an `ipython` instance and `import tourniquet`
 
+# Development
+
+Install venv to be able to run `make` commands
+
+```bash
+$ docker build -t trailofbits/tourniquet .
+$ docker run -it trailofbits/tourniquet
+root@b9f3a28655b6:/tourniquet# apt-get install -y python3-venv
+root@b9f3a28655b6:/tourniquet# python3 -m venv env
+root@b9f3a28655b6:/tourniquet# make test
+```
+
 # Contributors
 
 * Carson Harmon (carson.harmon@trailofbits.com)


### PR DESCRIPTION
This looks like it will shape up to be a pretty cool project, so I wanted to see about contributing. I ran through the Quickstart instructions and everything went well, but when I tried to run the tests, I realized that `venv` isn't installed in the Dockerfile. I imagine that this is by design because your target audience isn't trying to contribute to the codebase or run the tests, they're trying to use the tool.

Just in case you want other folks like me to be able to contribute, I felt like having a section for "Development" to include additional setup instructions would be useful.