### PR TITLE
Add test coverage make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,12 @@ test:
 	. env/bin/activate
 	pytest tests/
 
+.PHONY: test-cov
+.ONESHELL:
+test-cov:
+	. env/bin/activate
+	pytest --cov=tourniquet/ tests/
+
 .PHONY: doc
 .ONESHELL:
 doc:

--- a/setup.py
+++ b/setup.py
@@ -75,5 +75,5 @@ setup(
     ext_modules=[CMakeExtension(module_name)],
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,
-    extras_require={"dev": ["ipython", "pytest", "flake8", "black", "mypy", "isort"]},
+    extras_require={"dev": ["ipython", "pytest", "pytest-cov", "flake8", "black", "mypy", "isort"]},
 )


### PR DESCRIPTION
To start my contributions, I figured it would be an easy win to check what the test coverage was and write some additional unit tests to increase that coverage. We're currently sitting at 32%:

```
tests/test_tourniquet.py ...                                                                                                                                                                             [100%]

----------- coverage: platform linux, python 3.7.5-final-0 -----------
Name                       Stmts   Miss  Cover
----------------------------------------------
tourniquet/__init__.py         1      0   100%
tourniquet/patch_lang.py     201    133    34%
tourniquet/target.py          16     16     0%
tourniquet/tourniquet.py     162    110    32%
----------------------------------------------
TOTAL                        380    259    32%
```

Once we get to 100 (or as close as possible), we can add checks via CI to ensure that contributors also contribute tests for anything they add. The command for that will look like this (assuming we want to maintain 90% code coverage):

```bash
pytest --cov=tourniquet/ --cov-fail-under=90 tests/
```

I hope this helps!
