### PR TITLE
Stop extractor from being a standalone module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
     packages=find_packages(),
     version="1.0",
     description="Syntax Guided Repair/Transformation Package",
+    ext_package="tourniquet",
     ext_modules=[CMakeExtension(module_name)],
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,

--- a/tourniquet/tourniquet.py
+++ b/tourniquet/tourniquet.py
@@ -6,8 +6,7 @@ import subprocess
 from sqlite3 import Error
 from typing import Dict, Iterator, List, Optional
 
-import extractor
-
+from . import extractor  # type: ignore
 from .patch_lang import PatchTemplate
 
 


### PR DESCRIPTION
Fixes #10 

This puts extractor.so into the tourniquet/ directory when you run setup.py. The effect of this is that you can no longer just import extractor, you now just import tourniquet and use tourniquet.extractor  which I believe solves the issue.

```python
In [1]: import tourniquet
In [2]: import extractor
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-2-57e1f69885f8> in <module>
----> 1 import extractor
ModuleNotFoundError: No module named 'extractor'
In [3]: dir(tourniquet.extractor)
Out[3]: 
['__doc__',
 '__file__',
 '__loader__',
 '__name__',
 '__package__',
 '__spec__',
 'extract_ast',
 'transform']
```